### PR TITLE
'not_team_contributors' should be calculated based on all accounts, not only those accounts with profiles

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 volumes:
   postgres_data_dev: {}

--- a/package/views.py
+++ b/package/views.py
@@ -485,6 +485,11 @@ def package_detail(request, slug, template_name="package/package.html"):
         for ac in profile.account_set.all() if ac.type == Account.TYPE_GITHUB
     ]
 
+    # to handle accounts without profiles
+    for ac in package.team_members.all():
+        if ac.type == Account.TYPE_GITHUB and ac.pk not in all_github_accounts_of_teammambers:
+            all_github_accounts_of_teammambers.append(ac.pk)
+
     can_edit_package = hasattr(request.user, "profile") and request.user.profile.can_edit_package(package)
 
     return render(request, template_name,


### PR DESCRIPTION
There was a bug, which caused, that some accounts could be displayed in both sections (team and contributors).

![selection_163](https://user-images.githubusercontent.com/201263/36061207-704a80fc-0e57-11e8-8463-b078c816c285.png)

Now `not_team_contributors` is initialized based on all accounts (not only those with profiles).